### PR TITLE
added prisma output

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider      = "prisma-client-js"
   binaryTargets = ["native", "debian-openssl-3.0.x"]
+  output   = "../node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
This should fix the `Error: Cannot find module '.prisma/client/default'` when deploying to the new Azure Environment.

Similar to this issue:
https://stackoverflow.com/questions/78410369/cannot-find-module-prisma-client-default-when-using-prisma-extension-paginati